### PR TITLE
Unique ID Generation for Headings with Duplicate Titles

### DIFF
--- a/TableOfContents.php
+++ b/TableOfContents.php
@@ -222,7 +222,7 @@ class TableOfContents extends AbstractPicoPlugin
                 // Add missing id's to the h tags
                 $id = $curr_header->getAttribute('id');
                 if ($id === "") {
-                    $id = $this->slugify($curr_header->nodeValue);
+                    $id = $this->slugify($curr_header->nodeValue) . '-' . $index;
                     $curr_header->setAttribute('id', $id);
                 }
 


### PR DESCRIPTION
This commit addresses the issue where headings without an explicit ID resulted in ambiguous IDs for repeated headings (e.g., multiple "Summary" headings).

Changes made:
- PHP:
  - When a heading lacks an ID, a unique identifier is now generated by appending the heading's index to its content-derived ID. This ensures each heading ID is distinct, even when the heading text is repeated across the document.
