### PR TITLE
The show/hide symbols are now displayed at the correct time.

### DIFF
--- a/js/toc.js
+++ b/js/toc.js
@@ -9,11 +9,11 @@ if (toggleTocElement) {
                 if (xElement.classList.contains("toc-hide")) {
                     xElement.classList.remove("toc-hide");
                     xElement.classList.add("toc-show");
-                    this.innerText = this.getAttribute('data-show-text');
+                    this.innerText = this.getAttribute('data-hide-text');
                 } else if (xElement.classList.contains("toc-show")) {
                     xElement.classList.remove("toc-show");
                     xElement.classList.add("toc-hide");
-                    this.innerText = this.getAttribute('data-hide-text');
+                    this.innerText = this.getAttribute('data-show-text');
                 }
             }
         }


### PR DESCRIPTION
Removed a logic error in JavaScript.

The show/hide symbols are now displayed at the correct time.