### PR TITLE
Feature: Exclude Specific Tags When Extracting Text for TOC Entries

### DIFF
--- a/TableOfContents.php
+++ b/TableOfContents.php
@@ -230,7 +230,7 @@ class TableOfContents extends AbstractPicoPlugin
                 $li_element = $document->createElement('li');
                 $a_element = $document->createElement('a');
                 $a_element->setAttribute('href', "#$id");
-                $a_element->nodeValue = $curr_header->nodeValue;
+                $a_element->nodeValue = $this->extractTextWithoutCertainTags($curr_header, ['sup']);
                 $li_element->appendChild($a_element);
 
                 $next_header = ($index + 1 < $headers->length) ? $headers[$index + 1] : null;
@@ -252,6 +252,33 @@ class TableOfContents extends AbstractPicoPlugin
             }
         }
         return $list_element;
+    }
+
+    /**
+     * Extract text from a node without the text from certain tags.
+     *
+     * @param DOMNode $node
+     * @param string[] $ignoredTags
+     * @return string
+     */
+    private function extractTextWithoutCertainTags($node, $ignoredTags)
+    {
+        $text = '';
+
+        foreach ($node->childNodes as $child) {
+            if ($child->nodeType === XML_TEXT_NODE) {
+                // Add text from text nodes
+                $text .= $child->nodeValue;
+            } elseif ($child->nodeType === XML_ELEMENT_NODE) {
+                // Check if the current tag is not in the list of ignored tags
+                if (!in_array(strtolower($child->tagName), $ignoredTags, true)) {
+                    // Recursively get text from elements that are not in the ignored list
+                    $text .= $this->extractTextWithoutCertainTags($child, $ignoredTags);
+                }
+            }
+        }
+
+        return $text;
     }
 
     /**


### PR DESCRIPTION
## Overview
This Pull Request introduces an featureto the text extraction process used in generating the Table of Contents (TOC) for PicoCMS. Specifically, it adds the capability to exclude certain HTML tags (e.g., `<sup>`) from the text used in TOC entries.

## Changes Made
- Add the `extractTextWithoutCertainTags` function to accept an array of tag names (`$ignoredTags`) that should be excluded during text extraction.
- Updated the TOC generation logic to use this function, passing an array with the tag `'sup'`, ensuring that footnotes are not included in the TOC entries.
- The addition of this function increases the flexibility of the TOC generation process, allowing for cleaner TOC entries especially in documents where headers contain additional tags like footnotes or other annotations.

## Impact
- These changes allow for more readable and relevant TOC entries by excluding non-essential information (like footnotes) from the headers.
- The implementation maintains backward compatibility insofar as it only affects the presence of footnotes in the TOC. For users who do not include footnotes in headers or do not utilize the new exclusion feature, the TOC functionality remains unchanged.
