### PR TITLE
Fix: Update Twig_Markup Usage for Compatibility with Pico 3.0

### DIFF
--- a/TableOfContents.php
+++ b/TableOfContents.php
@@ -182,7 +182,7 @@ class TableOfContents extends AbstractPicoPlugin
      */
     public function onPageRendering(&$templateName, array &$twigVariables)
     {
-        $twigVariables['toc'] = new Twig_Markup($this->toc_element_xml, 'UTF-8');
+        $twigVariables['toc'] = new \Twig\Markup($this->toc_element_xml, 'UTF-8');
     }
 
     /* ********************************************************************************* */


### PR DESCRIPTION
## Introduction
This Pull Request addresses the compatibility issue with the `Pico:pico-3.0` branch, as discussed in Issue #16.

## Change Details
- Updated the usage of `Twig_Markup` to `\Twig\Markup` to align with the changes in PicoCMS 3.0.
- The modification ensures that the plugin remains compatible with PicoCMS 3.0 while maintaining backward compatibility with older versions.

## Code Modification
```diff
- $twigVariables['toc'] = new Twig_Markup($this->toc_element_xml, 'UTF-8');
+ $twigVariables['toc'] = new \Twig\Markup($this->toc_element_xml, 'UTF-8');
```
## Impact
- This change is critical for the plugin to function correctly with the latest version of PicoCMS (Pico 3.0).
- Ensures that the plugin remains usable for users who upgrade to PicoCMS 3.0, as well as those on older versions.